### PR TITLE
Icons fix - allow op2-groups to define literal sequence output blocks

### DIFF
--- a/OpenRA.Mods.OpenOP2/UtilityCommands/CreateSequencesCommand.cs
+++ b/OpenRA.Mods.OpenOP2/UtilityCommands/CreateSequencesCommand.cs
@@ -223,6 +223,12 @@ namespace OpenRA.Mods.OpenOP2.UtilityCommands
 						groupSequenceSet.Tick = tick;
 					}
 
+					var useFile = setNodes.FirstOrDefault(x => x.Key == "UseFile")?.Value?.Value?.ToString();
+					if (!string.IsNullOrEmpty(useFile))
+					{
+						groupSequenceSet.UseFile = useFile;
+					}
+
 					sets.Add(groupSequenceSet);
 				}
 
@@ -291,8 +297,16 @@ namespace OpenRA.Mods.OpenOP2.UtilityCommands
 					sets = AddSingleFrameIdle(sets);
 				}
 
+				var literalGroupSequenceSets = new List<GroupSequenceSet>();
+
 				foreach (var groupSequenceSet in sets)
 				{
+					if (!string.IsNullOrWhiteSpace(groupSequenceSet.UseFile))
+					{
+						literalGroupSequenceSets.Add(groupSequenceSet);
+						continue;
+					}
+
 					List<ImageGroup> groups;
 					if (groupSequenceSet.StartOffset > 0)
 					{
@@ -619,6 +633,16 @@ namespace OpenRA.Mods.OpenOP2.UtilityCommands
 					{
 						break;
 					}
+				}
+
+				// Hack in our literal sequences
+				// Used for icons only for now
+				foreach (var seq in literalGroupSequenceSets)
+				{
+					sb.AppendLine($"\t{seq.Sequence}: {seq.UseFile}");
+					sb.AppendLine($"\t\tStart: {seq.Start}");
+					sb.AppendLine($"\t\tLength: {seq.Length}");
+					sb.AppendLine($"\t\tOffset: {seq.OffsetX},{seq.OffsetY}");
 				}
 
 				sb.AppendLine(string.Empty);

--- a/OpenRA.Mods.OpenOP2/UtilityCommands/SequencesList.cs
+++ b/OpenRA.Mods.OpenOP2/UtilityCommands/SequencesList.cs
@@ -2,6 +2,8 @@
 {
 	public class GroupSequenceSet
 	{
+		public string UseFile { get; set; }
+
 		/// <summary>
 		/// Start ID of the group index.
 		/// </summary>

--- a/mods/openop2/op2-groups.yaml
+++ b/mods/openop2/op2-groups.yaml
@@ -12,6 +12,7 @@ eden-robo-dozer:
 			StartOffset: 2
 			Length: 8
 		Sequence: icon
+			UseFile: chromeedenrobodozer
 			Start: 0
 			Length: 1
 


### PR DESCRIPTION
Required to support icons from different image files than the actor it's attached to