### PR TITLE
Added a cmdlet to easily regenerate sequences

### DIFF
--- a/OpenRA.Mods.OpenOP2/UtilityCommands/CreateSequencesCommand.cs
+++ b/OpenRA.Mods.OpenOP2/UtilityCommands/CreateSequencesCommand.cs
@@ -94,9 +94,9 @@ namespace OpenRA.Mods.OpenOP2.UtilityCommands
 			public List<ActorOverlay> Overlays = new List<ActorOverlay>();
 		}
 
-		private const string OutputFilename = "..\\..\\mods\\openop2\\sequences\\sequences-generated.yaml";
-		private const string RulesOutputFilename = "..\\..\\mods\\openop2\\rules\\rules-generated.yaml";
-		private const string RulesExampleOutputFilename = "..\\..\\mods\\openop2\\rules\\rules-example.yaml";
+		private const string OutputFilename = "..\\mods\\openop2\\sequences\\sequences-generated.yaml";
+		private const string RulesOutputFilename = "..\\mods\\openop2\\rules\\rules-generated.yaml";
+		private const string RulesExampleOutputFilename = "..\\mods\\openop2\\rules\\rules-example.yaml";
 
 		string IUtilityCommand.Name => "--create-sequences";
 

--- a/create-sequences.cmd
+++ b/create-sequences.cmd
@@ -1,0 +1,11 @@
+@echo off
+set MOD_ID=openop2
+set MOD_SEARCH_PATHS=./../../mods,./../mods
+set ENGINE_DIR=./..
+set ENGINE_BIN_DIR=./engine/bin
+set TEMPLATE_DIR=%CD%
+cd %ENGINE_BIN_DIR%
+
+call OpenRA.Utility.exe %MOD_ID% --create-sequences
+pause
+exit /b

--- a/create-sequences.cmd
+++ b/create-sequences.cmd
@@ -1,11 +1,9 @@
 @echo off
-set MOD_ID=openop2
-set MOD_SEARCH_PATHS=./../../mods,./../mods
-set ENGINE_DIR=./..
-set ENGINE_BIN_DIR=./engine/bin
-set TEMPLATE_DIR=%CD%
-cd %ENGINE_BIN_DIR%
+set MOD_SEARCH_PATHS=./../mods,./mods
+set ENGINE_DIR=..
+cd engine
 
-call OpenRA.Utility.exe %MOD_ID% --create-sequences
+bin\OpenRA.Utility.exe openop2 --create-sequences
+
 pause
 exit /b

--- a/mods/openop2/create-sequences.cmd
+++ b/mods/openop2/create-sequences.cmd
@@ -1,7 +1,7 @@
 @echo off
 set MOD_SEARCH_PATHS=./../mods,./mods
 set ENGINE_DIR=..
-cd engine
+cd ../../engine
 
 bin\OpenRA.Utility.exe openop2 --create-sequences
 


### PR DESCRIPTION
There's a now a .cmd file in the main OpenOP2 directory that will run the `--create-sequences` command.