### PR TITLE
Fix facings for missile and laser sequences which have all facings in a single group

### DIFF
--- a/OpenRA.Mods.OpenOP2/UtilityCommands/CreateSequencesCommand.cs
+++ b/OpenRA.Mods.OpenOP2/UtilityCommands/CreateSequencesCommand.cs
@@ -144,8 +144,6 @@ namespace OpenRA.Mods.OpenOP2.UtilityCommands
 			var groupSequences = new List<GroupSequence>();
 			foreach (var group in yamlDefs)
 			{
-				var fart = group.Value.Nodes.First(x => x.Key == "ActorType").Value;
-
 				var groupNodes = group.Value.Nodes;
 				var groupSequence = new GroupSequence
 				{
@@ -225,6 +223,11 @@ namespace OpenRA.Mods.OpenOP2.UtilityCommands
 					if (int.TryParse(setNodes.FirstOrDefault(x => x.Key == "StartOffset")?.Value?.Value?.ToString(), out var startOffset))
 					{
 						groupSequenceSet.StartOffset = startOffset;
+					}
+
+					if (int.TryParse(setNodes.FirstOrDefault(x => x.Key == "FacingsOverride")?.Value?.Value?.ToString(), out var facingsOverride))
+					{
+						groupSequenceSet.FacingsOverride = facingsOverride;
 					}
 
 					if (int.TryParse(setNodes.FirstOrDefault(x => x.Key == "Tick")?.Value?.Value?.ToString(), out var tick))
@@ -328,7 +331,16 @@ namespace OpenRA.Mods.OpenOP2.UtilityCommands
 
 						sb.AppendLine($"\t{sequenceName}:");
 						sb.AppendLine($"\t\tLength: {frameCount}");
-						sb.AppendLine($"\t\tFacings: {groupSequenceSet.Length}");
+
+						if (groupSequenceSet.FacingsOverride > 0)
+						{
+							sb.AppendLine($"\t\tFacings: {groupSequenceSet.FacingsOverride}");
+						}
+						else
+						{
+							sb.AppendLine($"\t\tFacings: {groupSequenceSet.Length}");
+						}
+
 						sb.AppendLine($"\t\tOffset: {groupSequenceSet.OffsetX},{groupSequenceSet.OffsetY}");
 
 						if (groupSequenceSet.OffsetZ != 0)

--- a/OpenRA.Mods.OpenOP2/UtilityCommands/SequencesList.cs
+++ b/OpenRA.Mods.OpenOP2/UtilityCommands/SequencesList.cs
@@ -15,6 +15,8 @@
 		/// </summary>
 		public int Length { get; set; } = 1;
 
+		public int FacingsOverride { get; set; } = 0;
+
 		/// <summary>
 		/// Start from this group offset.
 		/// Groups will be read from the Start again after the last group.


### PR DESCRIPTION
Typically for OP2 sprites, each facing of a sprite has a different group ID:
![image](https://user-images.githubusercontent.com/1639681/131300314-292362aa-0957-4edf-a785-0e6497478820.png)

Not so for group ID 599, which looks like a projectile with 32 facings - this one has all the facings in just one group ID.
![image](https://user-images.githubusercontent.com/1639681/131300406-d1b90061-739a-423d-bcc1-9370ff0a8aff.png)

So we introduce a new flag in `op2-groups.yaml` to support this: `FacingsOverride`.

For group ID 599 you'll want something like:
```
missile:
    ActorType: Effect
    CreateBaseActor: True
    CreateExampleActor: False
    Sets:
        Sequence: idle
            Start: 599
            Length: 1
            FacingsOverride: 32
```